### PR TITLE
chore: replace go-findfont with goccy fork for WASM

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Client-side Spanner query plan viewer: React + Vite UI, Go WASM (`main.go`) for 
 
 GitHub Pages base path: `/rendertree-web/`.
 
-Graphviz in WASM pulls in `go-findfont` via `goccy/go-graphviz` (which replaces it with `github.com/goccy/go-findfont` including `js` build tags). No local stub is required.
+Graphviz in WASM pulls in `go-findfont` via `goccy/go-graphviz`. This repo mirrors go-graphviz’s `replace` to `github.com/goccy/go-findfont` (includes `js` build tags). No local stub is required.
 
 ## Before push
 

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
 	github.com/disintegration/imaging v1.6.2 // indirect
 	github.com/fatih/color v1.15.0 // indirect
-	github.com/flopp/go-findfont v0.1.1-0.20250313113053-2aa41f534f91 // indirect
+	github.com/flopp/go-findfont v0.1.0 // indirect
 	github.com/fogleman/gg v1.3.0 // indirect
 	github.com/goccy/go-graphviz v0.2.10 // indirect
 	github.com/goccy/go-yaml v1.17.1 // indirect
@@ -42,3 +42,5 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	sigs.k8s.io/yaml v1.2.0 // indirect
 )
+
+replace github.com/flopp/go-findfont => github.com/goccy/go-findfont v0.0.0-20250109093214-c2e12b298c75

--- a/go.sum
+++ b/go.sum
@@ -21,10 +21,10 @@ github.com/disintegration/imaging v1.6.2 h1:w1LecBlG2Lnp8B3jk5zSuNqd7b4DXhcjwek1
 github.com/disintegration/imaging v1.6.2/go.mod h1:44/5580QXChDfwIclfc/PCwrr44amcmDAg8hxG0Ewe4=
 github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=
 github.com/fatih/color v1.15.0/go.mod h1:0h5ZqXfHYED7Bhv2ZJamyIOUej9KtShiJESRwBDUSsw=
-github.com/flopp/go-findfont v0.1.1-0.20250313113053-2aa41f534f91 h1:SJOJsbzAkMrBBDzellzlxQm+feuBrEBaathALSGwIYg=
-github.com/flopp/go-findfont v0.1.1-0.20250313113053-2aa41f534f91/go.mod h1:bBfDkbCgtwEhoHfxProwm41bZX3SAcOHZbgbillrYQs=
 github.com/fogleman/gg v1.3.0 h1:/7zJX8F6AaYQc57WQCyN9cAIz+4bCJGO9B+dyW29am8=
 github.com/fogleman/gg v1.3.0/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
+github.com/goccy/go-findfont v0.0.0-20250109093214-c2e12b298c75 h1:XIuIPArJ/7VuKj7uygrjl7yBYP+sTa58ljJzOxU4qDc=
+github.com/goccy/go-findfont v0.0.0-20250109093214-c2e12b298c75/go.mod h1:bBfDkbCgtwEhoHfxProwm41bZX3SAcOHZbgbillrYQs=
 github.com/goccy/go-graphviz v0.2.10 h1:jHu/1I0Iw0xIzzYk96Ous/ZeuD11Rt2oW8juHdIE30g=
 github.com/goccy/go-graphviz v0.2.10/go.mod h1:LRlMnNmY17QbN6fLnvOzY7g0rXQjLKAhzxeTHbEUM6w=
 github.com/goccy/go-yaml v1.17.1 h1:LI34wktB2xEE3ONG/2Ar54+/HJVBriAGJ55PHls4YuY=


### PR DESCRIPTION
## Summary
- Add `replace github.com/flopp/go-findfont => github.com/goccy/go-findfont` matching `goccy/go-graphviz`
- Drop flopp master pseudo-version in favor of `v0.1.0` + replace (replace does not propagate from go-graphviz)
- Clarify AGENTS.md that this repo mirrors the replace explicitly

## Test plan
- [x] `go mod tidy`
- [x] `GOOS=js GOARCH=wasm go build`
- [x] `npm run typecheck`


Made with [Cursor](https://cursor.com)