### PR TITLE
chore(deps): bump spannerplanviz to v0.9.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24
 
 require (
 	github.com/apstndb/spannerplan v0.1.11
-	github.com/apstndb/spannerplanviz v0.9.1-0.20260707182421-56d576daa095
+	github.com/apstndb/spannerplanviz v0.9.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/apstndb/go-tabwrap v0.1.3 h1:5lO2M7Zl5NOus4cve0tu58j3txnNRAEd9MAsFitD
 github.com/apstndb/go-tabwrap v0.1.3/go.mod h1:duMNZZhNjqj/VXR2AXJN1MWko2RyIytSP1NJyhMmUV4=
 github.com/apstndb/spannerplan v0.1.11 h1:chLsajnYPQI2vwirOeBFNQU0sBWOx9Jet4DuM+zhg2c=
 github.com/apstndb/spannerplan v0.1.11/go.mod h1:7Xfm892U2wPhDrT5nf8NMEvEGtk7eGAh15Qa7e316HA=
-github.com/apstndb/spannerplanviz v0.9.1-0.20260707182421-56d576daa095 h1:T3FwSiuV8FN03DOnXY7A1S590aueLGD4Dxk9VjIRzpM=
-github.com/apstndb/spannerplanviz v0.9.1-0.20260707182421-56d576daa095/go.mod h1:ag8u3BrlvVrn0PeOgLsNHgUCxcF1MDtMo0NHyX4S4FA=
+github.com/apstndb/spannerplanviz v0.9.1 h1:6t5BaTKiunib0JVxbn/6jN4irUiUelyJEqQ1oqG8jpc=
+github.com/apstndb/spannerplanviz v0.9.1/go.mod h1:ag8u3BrlvVrn0PeOgLsNHgUCxcF1MDtMo0NHyX4S4FA=
 github.com/clipperhouse/displaywidth v0.11.0 h1:lBc6kY44VFw+TDx4I8opi/EtL9m20WSEFgwIwO+UVM8=
 github.com/clipperhouse/displaywidth v0.11.0/go.mod h1:bkrFNkf81G8HyVqmKGxsPufD3JhNl3dSqnGhOoSD/o0=
 github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJv2v7Vk=


### PR DESCRIPTION
Replaces the temporary `main` pseudo-version (introduced in #12) with the tagged spannerplanviz v0.9.1 release containing the `dot` package. No code changes; verified locally with `go test`, WASM build + size budgets, and the unit suite (84/84).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Du9UR1LPdSXk4wAZr4Nf4g