### PR TITLE
chore(deps): bump spannerplan to v0.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/apstndb/rendertree-web
 go 1.24
 
 require (
-	github.com/apstndb/spannerplan v0.1.11
+	github.com/apstndb/spannerplan v0.2.0
 	github.com/apstndb/spannerplanviz v0.9.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/MakeNowJust/heredoc/v2 v2.0.1 h1:rlCHh70XXXv7toz95ajQWOWQnN4WNLt0TdpZ
 github.com/MakeNowJust/heredoc/v2 v2.0.1/go.mod h1:6/2Abh5s+hc3g9nbWLe9ObDIOhaRrqsyY9MWy+4JdRM=
 github.com/apstndb/go-tabwrap v0.1.3 h1:5lO2M7Zl5NOus4cve0tu58j3txnNRAEd9MAsFitDCQw=
 github.com/apstndb/go-tabwrap v0.1.3/go.mod h1:duMNZZhNjqj/VXR2AXJN1MWko2RyIytSP1NJyhMmUV4=
-github.com/apstndb/spannerplan v0.1.11 h1:chLsajnYPQI2vwirOeBFNQU0sBWOx9Jet4DuM+zhg2c=
-github.com/apstndb/spannerplan v0.1.11/go.mod h1:7Xfm892U2wPhDrT5nf8NMEvEGtk7eGAh15Qa7e316HA=
+github.com/apstndb/spannerplan v0.2.0 h1:mQyyEHaw2PmDPvum5FQC41+25zb75H35KUm4HKuj6jI=
+github.com/apstndb/spannerplan v0.2.0/go.mod h1:7Xfm892U2wPhDrT5nf8NMEvEGtk7eGAh15Qa7e316HA=
 github.com/apstndb/spannerplanviz v0.9.1 h1:6t5BaTKiunib0JVxbn/6jN4irUiUelyJEqQ1oqG8jpc=
 github.com/apstndb/spannerplanviz v0.9.1/go.mod h1:ag8u3BrlvVrn0PeOgLsNHgUCxcF1MDtMo0NHyX4S4FA=
 github.com/clipperhouse/displaywidth v0.11.0 h1:lBc6kY44VFw+TDx4I8opi/EtL9m20WSEFgwIwO+UVM8=


### PR DESCRIPTION
## Summary

Bumps `github.com/apstndb/spannerplan` from v0.1.11 to v0.2.0. `github.com/apstndb/spannerplanviz` stays at v0.9.1.

## Validation

- `go test ./...` passes.
- WASM build succeeds: `GOOS=js GOARCH=wasm go build -ldflags="-s -w" -o dist/rendertree.wasm ./`
- `npm run check:wasm-size` within budget:
  - raw 24.22 MiB (budget 28.00 MiB)
  - gzip 5.29 MiB (budget 6.50 MiB)
  - brotli 3.73 MiB (budget 5.50 MiB)
- `npx vitest run`: all 84 tests pass, including the node-integration suite that loads the rebuilt WASM. No ASCII/rendering assertion changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Du9UR1LPdSXk4wAZr4Nf4g