### PR TITLE
feat: add D2 source output view

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Client-side Spanner query plan viewer: React + Vite UI, Go WASM (`main.go`) for 
 
 | Area | Role |
 |------|------|
-| `main.go` | WASM entry: `renderASCII`, `renderMermaid`, `renderDOT` (spannerplanviz) |
+| `main.go` | WASM entry: `renderASCII`, `renderMermaid`, `renderDOT`, `renderD2` (spannerplanviz) |
 | `src/wasm.ts`, `src/types/wasm.ts` | JS ↔ WASM bridge and types |
 | `WasmContext` / `AppContext` | Module load vs UI state |
 | `InputPanel` / `OutputPanel` | Input, ASCII or Diagram output |

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/apstndb/spannerplan v0.2.1
-	github.com/apstndb/spannerplanviz v0.10.0
+	github.com/apstndb/spannerplanviz v0.10.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/apstndb/protoyaml v0.1.0 h1:xbps9Yly1rciJhLOFdA+KLIdEpEcIaTCboFB3QtUM
 github.com/apstndb/protoyaml v0.1.0/go.mod h1:bsZCSj3nYZKfLiKRogOxuUjlURUOJpBb+G5f1b3g5Fc=
 github.com/apstndb/spannerplan v0.2.1 h1:vzuUI2u1x+tF/ZGRYutnVJbF/n51RxIgOhn+MoNBaiE=
 github.com/apstndb/spannerplan v0.2.1/go.mod h1:X61lDATo/rDsn9gHTvlOUfm0SItUFL32QJWcRHalWnA=
-github.com/apstndb/spannerplanviz v0.10.0 h1:yOXkOwxNl36b6pUMKZuq3Okw/9VWcViDDwQTQbIyjUU=
-github.com/apstndb/spannerplanviz v0.10.0/go.mod h1:1g6dWQcxamHr/2VgVoQSW1vGogZ/J7+ZESYRNEFjAxU=
+github.com/apstndb/spannerplanviz v0.10.1 h1:iF8QP9e/CkgOpTYXuJTDVdViSqvTumRvcHRYEpb6H5Y=
+github.com/apstndb/spannerplanviz v0.10.1/go.mod h1:1g6dWQcxamHr/2VgVoQSW1vGogZ/J7+ZESYRNEFjAxU=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/clipperhouse/displaywidth v0.11.0 h1:lBc6kY44VFw+TDx4I8opi/EtL9m20WSEFgwIwO+UVM8=

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 
 	queryplan "github.com/apstndb/spannerplan"
 	"github.com/apstndb/spannerplan/plantree/reference"
+	"github.com/apstndb/spannerplanviz/d2"
 	"github.com/apstndb/spannerplanviz/dot"
 	"github.com/apstndb/spannerplanviz/mermaid"
 	"github.com/apstndb/spannerplanviz/visualize"
@@ -169,6 +170,16 @@ func renderDOT(_ js.Value, args []js.Value) any {
 	})
 }
 
+func renderD2(_ js.Value, args []js.Value) any {
+	return invokeWasm(args, func(paramsJSON string) (string, error) {
+		par := planVizParams{}
+		if err := json.Unmarshal([]byte(paramsJSON), &par); err != nil {
+			return "", ParseError{msg: fmt.Sprintf("Failed to parse parameters: %v", err)}
+		}
+		return renderD2Impl(par)
+	})
+}
+
 // classifyError determines the error type using errors.As for type-safe classification
 func classifyError(err error) string {
 	// Check for custom error types first
@@ -311,10 +322,27 @@ func renderDOTImpl(par planVizParams) (string, error) {
 	return src, nil
 }
 
+// renderD2Impl returns D2 (https://d2lang.com) diagram source text. Layout and
+// image generation happen externally via the d2 CLI, so the WASM binary does
+// not embed a D2 runtime (the official D2 browser bundle is far too large).
+func renderD2Impl(par planVizParams) (string, error) {
+	plan, err := buildPlanFromParams(par)
+	if err != nil {
+		return "", err
+	}
+
+	src, err := d2.Source(plan)
+	if err != nil {
+		return "", RenderError{msg: fmt.Sprintf("Failed to render D2 source: %v", err)}
+	}
+	return src, nil
+}
+
 func main() {
 	js.Global().Set("renderASCII", js.FuncOf(renderASCII))
 	js.Global().Set("renderMermaid", js.FuncOf(renderMermaid))
 	js.Global().Set("renderDOT", js.FuncOf(renderDOT))
+	js.Global().Set("renderD2", js.FuncOf(renderD2))
 	c := make(<-chan struct{})
 	<-c
 }

--- a/src/components/InputPanel.tsx
+++ b/src/components/InputPanel.tsx
@@ -97,7 +97,12 @@ const InputPanel: React.FC<InputPanelProps> = ({ disabled }) => {
   }, [wrapWidth]);
 
   const appendixPreset = presetForSections(printSections);
-  const isPlanVizView = outputView === 'diagram' || outputView === 'svg';
+  // The diagram/svg/d2 views all build the plan via the spannerplanviz pipeline
+  // and share the "full details" toggle instead of the ASCII text controls.
+  const isPlanVizView = outputView === 'diagram' || outputView === 'svg' || outputView === 'd2';
+  // Only the rendered graphical views (diagram/svg) are zoomable; the D2 view is
+  // monospace source text, so it keeps the font-size controls like ASCII.
+  const isZoomableView = outputView === 'diagram' || outputView === 'svg';
   const [showPlanInput, setShowPlanInput] = useState(false);
 
   const onFileUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -223,6 +228,7 @@ const InputPanel: React.FC<InputPanelProps> = ({ disabled }) => {
             <option value="ascii">ASCII tree</option>
             <option value="diagram">Diagram (Mermaid)</option>
             <option value="svg">Diagram (Graphviz SVG)</option>
+            <option value="d2">D2 source</option>
           </select>
         </div>
         {isPlanVizView ? (
@@ -333,7 +339,7 @@ const InputPanel: React.FC<InputPanelProps> = ({ disabled }) => {
         >
           🔄 Refresh
         </button>
-        {isPlanVizView ? (
+        {isZoomableView ? (
           <DiagramZoomControls
             diagramZoom={diagramZoom}
             setDiagramZoom={setDiagramZoom}

--- a/src/components/OutputPanel.tsx
+++ b/src/components/OutputPanel.tsx
@@ -12,7 +12,7 @@ import { useDiagramZoomGestures } from '../hooks/useDiagramZoomGestures';
 import { useScrollTracking } from '../hooks/useScrollTracking';
 
 const OutputPanel: React.FC = () => {
-  const { asciiOutput, diagramOutput, svgOutput, message, isRendering } = useAppContext();
+  const { asciiOutput, diagramOutput, svgOutput, d2Output, message, isRendering } = useAppContext();
   const { fontSize, diagramZoom, setDiagramZoom, outputView, registerDiagramFitHandler } = useSettingsContext();
   // WASM initializes lazily inside the render call, so the render lifecycle
   // (isRendering) is the single source of the loading indicator -- it covers
@@ -20,8 +20,15 @@ const OutputPanel: React.FC = () => {
   const isLoading = isRendering;
   const isDiagramView = outputView === 'diagram';
   const isSvgView = outputView === 'svg';
+  const isD2View = outputView === 'd2';
   const isZoomableView = isDiagramView || isSvgView;
-  const activeOutput = isDiagramView ? diagramOutput : isSvgView ? svgOutput : asciiOutput;
+  const activeOutput = isDiagramView
+    ? diagramOutput
+    : isSvgView
+      ? svgOutput
+      : isD2View
+        ? d2Output
+        : asciiOutput;
 
   const preRef = useRef<HTMLPreElement>(null);
   const codeRef = useRef<HTMLElement>(null);
@@ -37,7 +44,7 @@ const OutputPanel: React.FC = () => {
   const { scrollLeft, rulerWidth } = useScrollTracking(
     preRef,
     codeRef,
-    isZoomableView ? '' : asciiOutput,
+    outputView === 'ascii' ? asciiOutput : '',
     fontSize,
     "Consolas, 'Courier New', Courier, monospace"
   );
@@ -173,6 +180,47 @@ const OutputPanel: React.FC = () => {
           <OutputActionButtons
             content={asciiOutput}
             download={OUTPUT_DOWNLOAD.ascii}
+          />
+        </div>
+      )}
+
+      {isD2View && d2Output && (
+        <div
+          className="pre-container"
+          data-testid="output-container"
+        >
+          <div className="d2-hint" data-testid="d2-hint">
+            Render with the D2 CLI: <code>d2 plan.d2 plan.svg</code>
+          </div>
+          <pre
+            style={{
+              fontFamily: 'monospace',
+              whiteSpace: 'pre',
+              border: 'solid',
+              padding: '10px',
+              marginTop: '0',
+              position: 'relative',
+              overflow: 'auto',
+              maxWidth: '100%',
+              flex: '1 1 auto',
+              boxSizing: 'border-box',
+              margin: '0',
+            }}
+          >
+            <code
+              style={{
+                fontFamily: "Consolas, 'Courier New', Courier, monospace",
+                fontSize: `${fontSize}px`,
+              }}
+              data-testid="d2-output-code"
+            >
+              {d2Output}
+            </code>
+          </pre>
+
+          <OutputActionButtons
+            content={d2Output}
+            download={OUTPUT_DOWNLOAD.d2}
           />
         </div>
       )}

--- a/src/contexts/AppContext.tsx
+++ b/src/contexts/AppContext.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from 'react';
 import { createContextWithHook } from '../utils/createContextWithHook';
 import { useFileContext } from './FileContext';
 import { useSettingsContext } from './SettingsContext';
-import { renderASCIITree, renderMermaidDiagram, renderSVGDiagram, isWasmInitialized } from '../wasm';
+import { renderASCIITree, renderMermaidDiagram, renderSVGDiagram, renderD2Source, isWasmInitialized } from '../wasm';
 import type { FormatType, PrintSection, RenderAppendixOptions } from '../types/wasm';
 import { logger } from '../utils/logger';
 
@@ -21,6 +21,7 @@ interface AppState {
   asciiOutput: string;
   diagramOutput: string;
   svgOutput: string;
+  d2Output: string;
   message: string;
   isRendering: boolean;
 }
@@ -58,6 +59,7 @@ export const AppProvider: React.FC<AppProviderProps> = ({ children }) => {
   const [asciiOutput, setAsciiOutput] = useState<string>('');
   const [diagramOutput, setDiagramOutput] = useState<string>('');
   const [svgOutput, setSvgOutput] = useState<string>('');
+  const [d2Output, setD2Output] = useState<string>('');
   const [isRendering, setIsRendering] = useState<boolean>(false);
   // The WASM module is initialized lazily on the first render (see wasm.ts),
   // so the app is immediately usable and starts in a ready state.
@@ -88,6 +90,8 @@ export const AppProvider: React.FC<AppProviderProps> = ({ children }) => {
         rendered = await renderMermaidDiagram(input, { full: diagramFull });
       } else if (outputView === 'svg') {
         rendered = await renderSVGDiagram(input, { full: diagramFull });
+      } else if (outputView === 'd2') {
+        rendered = await renderD2Source(input, { full: diagramFull });
       } else {
         const appendixOptions: RenderAppendixOptions = {
           showScalarVars,
@@ -102,6 +106,8 @@ export const AppProvider: React.FC<AppProviderProps> = ({ children }) => {
         setDiagramOutput(rendered);
       } else if (outputView === 'svg') {
         setSvgOutput(rendered);
+      } else if (outputView === 'd2') {
+        setD2Output(rendered);
       } else {
         setAsciiOutput(rendered);
       }
@@ -184,6 +190,7 @@ export const AppProvider: React.FC<AppProviderProps> = ({ children }) => {
     asciiOutput,
     diagramOutput,
     svgOutput,
+    d2Output,
     message,
     isRendering,
     handleRender,

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -25,7 +25,7 @@ interface SettingsProviderProps {
 }
 
 const isOutputView = (value: string | null): value is OutputView =>
-  value === 'ascii' || value === 'diagram' || value === 'svg';
+  value === 'ascii' || value === 'diagram' || value === 'svg' || value === 'd2';
 
 export const MIN_DIAGRAM_ZOOM = 5;
 export const MAX_DIAGRAM_ZOOM = 500;

--- a/src/index.css
+++ b/src/index.css
@@ -316,6 +316,21 @@ textarea.input-area {
   min-height: 0;
 }
 
+.d2-hint {
+  padding: 6px 10px;
+  font-size: 13px;
+  color: #495057;
+  background-color: #f0f8ff;
+  border-bottom: 1px solid #dee2e6;
+}
+
+.d2-hint code {
+  font-family: Consolas, 'Courier New', Courier, monospace;
+  background-color: #e9ecef;
+  padding: 1px 4px;
+  border-radius: 3px;
+}
+
 /* Rendering control styles */
 .render-controls {
   /* display: flex; Removed as it's now a column flex container */

--- a/src/types/__tests__/wasm-node-integration.test.ts
+++ b/src/types/__tests__/wasm-node-integration.test.ts
@@ -20,6 +20,7 @@ declare global {
   };
   var renderASCII: (paramsJson: string) => string;
   var renderMermaid: (paramsJson: string) => string;
+  var renderD2: (paramsJson: string) => string;
 }
 
 const scalarAppendixInput = `
@@ -99,6 +100,7 @@ describe('WASM Node.js Integration Tests', () => {
   let renderASCII: (paramsJson: string) => string;
   let renderMermaid: (paramsJson: string) => string;
   let renderDOT: (paramsJson: string) => string;
+  let renderD2: (paramsJson: string) => string;
 
   beforeAll(async () => {
     // Load and execute wasm_exec.js in Node.js environment
@@ -168,7 +170,8 @@ describe('WASM Node.js Integration Tests', () => {
     renderASCII = (globalThis as Record<string, unknown>).renderASCII as (paramsJson: string) => string;
     renderMermaid = (globalThis as Record<string, unknown>).renderMermaid as (paramsJson: string) => string;
     renderDOT = (globalThis as Record<string, unknown>).renderDOT as (paramsJson: string) => string;
-    
+    renderD2 = (globalThis as Record<string, unknown>).renderD2 as (paramsJson: string) => string;
+
     if (typeof renderASCII !== 'function') {
       throw new Error('renderASCII function not available after WASM initialization');
     }
@@ -177,6 +180,9 @@ describe('WASM Node.js Integration Tests', () => {
     }
     if (typeof renderDOT !== 'function') {
       throw new Error('renderDOT function not available after WASM initialization');
+    }
+    if (typeof renderD2 !== 'function') {
+      throw new Error('renderD2 function not available after WASM initialization');
     }
     
     // WASM module initialized successfully in Node.js
@@ -353,6 +359,51 @@ stats:
       expect(response.result).toContain('digraph {');
       expect(response.result).toContain('Distributed Union');
       expect(response.result).toContain('Scan');
+    });
+  });
+
+  describe('renderD2', () => {
+    it('should return D2 source for a valid query plan', () => {
+      const params: RenderMermaidParams = {
+        input: `
+stats:
+  queryPlan:
+    planNodes:
+      - displayName: "Distributed Union"
+        kind: RELATIONAL
+        index: 0
+        childLinks:
+          - childIndex: 1
+      - displayName: "Scan"
+        kind: RELATIONAL
+        index: 1
+`,
+        full: true,
+      };
+
+      const resultStr = renderD2(JSON.stringify(params));
+      const response: WasmResponse = JSON.parse(resultStr);
+
+      expect(response.success).toBe(true);
+      expect(response.result).toContain('direction: down');
+      expect(response.result).toContain('Distributed Union');
+      expect(response.result).toContain('Scan');
+    });
+
+    it('should return INVALID_SPANNER_FORMAT for missing plan nodes', () => {
+      const params: RenderMermaidParams = {
+        input: `
+stats:
+  queryPlan: {}
+`,
+        full: true,
+      };
+
+      const resultStr = renderD2(JSON.stringify(params));
+      const response: WasmResponse = JSON.parse(resultStr);
+
+      expect(response.success).toBe(false);
+      expect(response.error?.type).toBe('INVALID_SPANNER_FORMAT');
     });
   });
 

--- a/src/types/__tests__/wasm.test.ts
+++ b/src/types/__tests__/wasm.test.ts
@@ -65,15 +65,23 @@ describe('WASM types', () => {
 
     const mockRenderDOT = (): string => 'digraph { "node0" [shape="box"]; }';
 
+    const mockRenderD2 = (paramsJson: string): string => {
+      const params = JSON.parse(paramsJson);
+      return `direction: down\nnode0.label: |md **${params.input}** |`;
+    };
+
     const wasmFunctions: WasmFunctions = {
       renderASCII: mockRenderASCII,
       renderMermaid: mockRenderMermaid,
       renderDOT: mockRenderDOT,
+      renderD2: mockRenderD2,
     };
 
     expect(typeof wasmFunctions.renderASCII).toBe('function');
     expect(typeof wasmFunctions.renderMermaid).toBe('function');
     expect(typeof wasmFunctions.renderDOT).toBe('function');
+    expect(typeof wasmFunctions.renderD2).toBe('function');
+    expect(wasmFunctions.renderD2(JSON.stringify({ input: 'plan' }))).toContain('direction: down');
     
     const testParams = JSON.stringify({
       input: 'test',

--- a/src/types/wasm.ts
+++ b/src/types/wasm.ts
@@ -43,8 +43,9 @@ export interface RenderAppendixOptions {
  * - ascii: Text tree rendered by spannerplan/plantree
  * - diagram: Mermaid.js diagram rendered in the browser
  * - svg: Graphviz SVG laid out in the browser from spannerplanviz DOT source
+ * - d2: D2 (https://d2lang.com) diagram source text; render externally with the d2 CLI
  */
-export type OutputView = "ascii" | "diagram" | "svg";
+export type OutputView = "ascii" | "diagram" | "svg" | "d2";
 
 /**
  * Parameters for WASM renderMermaid/renderDOT functions
@@ -146,4 +147,12 @@ export interface WasmFunctions {
    * @returns JSON string containing WasmResponse
    */
   renderDOT: (paramsJson: string) => string;
+  /**
+   * Renders Spanner query plan as D2 (https://d2lang.com) diagram source text.
+   * The result is unlaid-out D2 source; render it externally with the d2 CLI
+   * (for example `d2 plan.d2 plan.svg`). No in-browser rendering is performed.
+   * @param paramsJson - JSON string containing RenderPlanVizParams
+   * @returns JSON string containing WasmResponse
+   */
+  renderD2: (paramsJson: string) => string;
 }

--- a/src/utils/downloadFile.ts
+++ b/src/utils/downloadFile.ts
@@ -3,7 +3,7 @@ export interface DownloadDescriptor {
   mimeType: string;
 }
 
-export const OUTPUT_DOWNLOAD: Record<'ascii' | 'diagram' | 'svg', DownloadDescriptor> = {
+export const OUTPUT_DOWNLOAD: Record<'ascii' | 'diagram' | 'svg' | 'd2', DownloadDescriptor> = {
   ascii: {
     filename: 'query-plan.txt',
     mimeType: 'text/plain;charset=utf-8',
@@ -15,6 +15,10 @@ export const OUTPUT_DOWNLOAD: Record<'ascii' | 'diagram' | 'svg', DownloadDescri
   svg: {
     filename: 'query-plan.svg',
     mimeType: 'image/svg+xml;charset=utf-8',
+  },
+  d2: {
+    filename: 'query-plan.d2',
+    mimeType: 'text/plain;charset=utf-8',
   },
 };
 

--- a/src/wasm.ts
+++ b/src/wasm.ts
@@ -11,6 +11,7 @@ import { extractErrorInfo } from './utils/errorHandling';
 declare function renderASCII(paramsJson: string): string;
 declare function renderMermaid(paramsJson: string): string;
 declare function renderDOT(paramsJson: string): string;
+declare function renderD2(paramsJson: string): string;
 
 let cachedWasmFunctions: WasmFunctions | null = null;
 let initPromise: Promise<WasmFunctions> | null = null;
@@ -118,7 +119,7 @@ async function initializeWasm(): Promise<WasmFunctions> {
     const result = await WebAssembly.instantiateStreaming(fetchResponse, go.importObject);
     void go.run(result.instance);
 
-    cachedWasmFunctions = { renderASCII, renderMermaid, renderDOT };
+    cachedWasmFunctions = { renderASCII, renderMermaid, renderDOT, renderD2 };
     logger.info('WASM initialization completed successfully');
     return cachedWasmFunctions;
   } catch (e) {
@@ -181,6 +182,34 @@ export async function renderMermaidDiagram(
   } catch (e) {
     const { message, originalError } = extractErrorInfo(e);
     logger.error('Error during mermaid rendering:', message);
+    throw new WasmRenderingError(message, originalError);
+  }
+}
+
+/**
+ * Render D2 (https://d2lang.com) diagram source text for a query plan via WASM.
+ *
+ * Unlike the SVG view, no in-browser layout happens: the official D2 browser
+ * bundle is far too large to ship, so this returns the raw D2 source for the
+ * user to render externally with the d2 CLI (for example `d2 plan.d2 plan.svg`).
+ */
+export async function renderD2Source(
+  input: string,
+  options: Omit<RenderPlanVizParams, 'input'> = { full: true }
+): Promise<string> {
+  logger.info('renderD2Source called');
+  logger.debug('Input length:', input.length, 'characters');
+
+  try {
+    const wasmFunctions = await initWasm();
+    const params: RenderPlanVizParams = {
+      input,
+      ...options,
+    };
+    return invokeWasm(wasmFunctions.renderD2, JSON.stringify(params));
+  } catch (e) {
+    const { message, originalError } = extractErrorInfo(e);
+    logger.error('Error during D2 rendering:', message);
     throw new WasmRenderingError(message, originalError);
   }
 }

--- a/tests/d2-rendering.spec.ts
+++ b/tests/d2-rendering.spec.ts
@@ -1,0 +1,70 @@
+import { test, expect } from '@playwright/test';
+import {
+  setupCompleteTest,
+  uploadTestFile,
+  selectOutputView,
+} from './utils';
+
+const DEBUG = process.env.DEBUG === 'true';
+
+test.describe('D2 Source Rendering', () => {
+  test.setTimeout(120000);
+
+  test('should render a query plan as D2 source text', async ({ page }) => {
+    await setupCompleteTest(page, test, { debug: DEBUG });
+    await selectOutputView(page, 'd2');
+    await uploadTestFile(page, 'dca_profile.yaml');
+
+    const output = page.getByTestId('d2-output-code');
+    await expect(output).toContainText('direction: down', { timeout: 60000 });
+    await expect(output).toContainText('node0');
+    await expect(output).toContainText(/Distributed/i);
+
+    // The hint tells users how to render the source externally with the d2 CLI.
+    await expect(page.getByTestId('d2-hint')).toContainText('d2 plan.d2 plan.svg');
+  });
+
+  test('should switch between ASCII and D2 views', async ({ page }) => {
+    await setupCompleteTest(page, test, { debug: DEBUG });
+    await uploadTestFile(page, 'dca_profile.yaml');
+
+    await expect(page.getByTestId('output-code')).toContainText('Distributed Union', { timeout: 60000 });
+
+    await selectOutputView(page, 'd2');
+    await expect(page.getByTestId('d2-output-code')).toContainText('direction: down', { timeout: 60000 });
+    await expect(page.getByTestId('output-code')).toHaveCount(0);
+
+    await selectOutputView(page, 'ascii');
+    await expect(page.getByTestId('output-code')).toContainText('Distributed Union', { timeout: 60000 });
+    await expect(page.getByTestId('d2-output-code')).toHaveCount(0);
+  });
+
+  test('should download D2 source with d2 extension', async ({ page }) => {
+    await setupCompleteTest(page, test, { debug: DEBUG });
+    await selectOutputView(page, 'd2');
+    await uploadTestFile(page, 'dca_profile.yaml');
+    await expect(page.getByTestId('d2-output-code')).toContainText('direction: down', { timeout: 60000 });
+
+    const downloadPromise = page.waitForEvent('download');
+    await page.getByTestId('download-button').click();
+    const download = await downloadPromise;
+
+    expect(download.suggestedFilename()).toBe('query-plan.d2');
+  });
+
+  test('should keep D2 source copyable', async ({ page, browserName }) => {
+    test.skip(browserName !== 'chromium', 'Clipboard permissions are configured for Chromium only');
+
+    await setupCompleteTest(page, test, { debug: DEBUG });
+    await selectOutputView(page, 'd2');
+    await uploadTestFile(page, 'dca_profile.yaml');
+    await expect(page.getByTestId('d2-output-code')).toContainText('direction: down', { timeout: 60000 });
+
+    await page.getByTestId('copy-button').click();
+    await expect(page.getByTestId('copy-button')).toHaveText(/copied/i, { timeout: 5000 });
+
+    const clipboardText = await page.evaluate(async () => navigator.clipboard.readText());
+    expect(clipboardText).toContain('direction: down');
+    expect(clipboardText).toContain('node0');
+  });
+});

--- a/tests/utils/fileHelpers.ts
+++ b/tests/utils/fileHelpers.ts
@@ -95,7 +95,7 @@ export async function waitForDiagramComplete(
  */
 export async function selectOutputView(
   page: Page,
-  view: 'ascii' | 'diagram' | 'svg',
+  view: 'ascii' | 'diagram' | 'svg' | 'd2',
 ): Promise<void> {
   await page.getByTestId('output-view-select').selectOption(view);
 }


### PR DESCRIPTION
## Summary

Adds a **D2** ([d2lang.com](https://d2lang.com)) source output view alongside the existing ASCII, Mermaid, and Graphviz SVG views.

The view shows **D2 diagram source text only** — there is no in-browser rendering. The official D2 browser bundle is ~6 MB gzip, which was rejected for bundle-size reasons. Users copy or download the source and render it externally with the d2 CLI (e.g. `d2 plan.d2 plan.svg`). No plan data is ever sent to an external service.

## Changes

- **`main.go`**: expose `renderD2` via `spannerplanviz/d2.Source`, mirroring `renderMermaid`/`renderDOT`. Bumps `spannerplanviz` to `v0.10.1`.
- **`src/types/wasm.ts`, `src/wasm.ts`**: add `renderD2` to the WASM contract; export `renderD2Source` (returns the source string, no browser layout step); extend the `OutputView` union with `"d2"`.
- **UI**: new "D2 source" output view — `SettingsContext` persistence, `InputPanel` selector option, `AppContext` `d2Output` state + render branch, and an `OutputPanel` monospace text panel with the existing copy/download buttons (`.d2` extension, `text/plain`) plus a d2 CLI hint. The D2 view builds the plan through the spannerplanviz pipeline (shares the full-details toggle) but keeps the font-size controls since it is text, not a zoomable diagram.
- **Tests**: extended WASM unit + Node integration tests (real WASM `renderD2` asserts `direction: down` and node labels) and a new `tests/d2-rendering.spec.ts` E2E spec.

## Validation

- `go test ./...`: pass
- WASM build (`-ldflags="-s -w"`): raw 24.34 MiB / gzip 5.27 MiB / brotli 3.71 MiB — all within budget (D2 is text-only; negligible growth, ~+51 KB raw)
- `npm run lint`, `npm run typecheck`: pass
- `npx vitest run`: 86 passed
- `npx playwright test --project=chromium`: 24 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Du9UR1LPdSXk4wAZr4Nf4g