### PR TITLE
feat: render D2 diagram in-browser via lazy @terrastruct/d2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,8 @@ GitHub Pages base path: `/rendertree-web/`.
 
 Graphviz layout runs in the browser: Go WASM emits DOT source (`spannerplanviz/dot`), and `src/wasm.ts` lazily loads `@hpcc-js/wasm-graphviz` to produce SVG. Do not reintroduce `goccy/go-graphviz` into the Go module — it embeds a Graphviz WASM runtime plus a font stack and roughly doubles the binary (CI enforces budgets via `npm run check:wasm-size`).
 
+D2 diagrams are also rendered in the browser: Go WASM emits D2 source (`renderD2`), and `src/wasm.ts` lazily loads `@terrastruct/d2` (`renderD2Diagram`) to compile+lay-out the source to SVG. That browser bundle is large (~8 MB raw, wasm embedded, self-hosted web worker), so it is dynamically imported as its own lazy chunk; `npm run check:chunk-size` tracks both the Graphviz and D2 chunks as regression detectors (not hard limits — the D2 chunk size is accepted). Copy/Download on the D2 view still operate on the raw D2 source (`.d2`), so users can render it externally with the d2 CLI.
+
 ## Before push
 
 CI runs **`tsc`** in both Tests (`npm run typecheck`) and Deploy (`npm run build`). These do **not** run typecheck:

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@hpcc-js/wasm-graphviz": "^1.24.1",
+        "@terrastruct/d2": "^0.1.33",
         "loglevel": "^1.9.2",
         "mermaid": "^11.16.0",
         "react": "^18.2.0",
@@ -1590,6 +1591,12 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@terrastruct/d2": {
+      "version": "0.1.33",
+      "resolved": "https://registry.npmjs.org/@terrastruct/d2/-/d2-0.1.33.tgz",
+      "integrity": "sha512-eK5hyfGIJFolC7sUsiKvWdY9xGFctTe3d+PSijo09IYDso8psztC+A4SammizXtlwYZpnnW0AtDjfBYauceSeA==",
+      "license": "MPL-2.0"
     },
     "node_modules/@testing-library/dom": {
       "version": "10.4.0",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
   },
   "dependencies": {
     "@hpcc-js/wasm-graphviz": "^1.24.1",
+    "@terrastruct/d2": "^0.1.33",
     "loglevel": "^1.9.2",
     "mermaid": "^11.16.0",
     "react": "^18.2.0",

--- a/scripts/check-chunk-size.mjs
+++ b/scripts/check-chunk-size.mjs
@@ -1,20 +1,28 @@
-// Bundle-chunk budget for the lazily-loaded Graphviz layout engine.
+// Bundle-chunk budgets for the lazily-loaded rendering engines.
 //
-// @hpcc-js/wasm-graphviz is dynamically imported (see src/wasm.ts) so its
-// wasm-bearing JS chunk is only downloaded when the Graphviz SVG view is
-// used. This check keeps that chunk from silently ballooning -- e.g. a
-// dependency bump that inlines more, or an accidental static import that
-// folds Graphviz into the entry bundle and defeats the lazy load.
+// Two heavy third-party engines are dynamically imported (see src/wasm.ts) so
+// their wasm-bearing JS chunks are only downloaded when the matching view is
+// used:
+//   - @hpcc-js/wasm-graphviz  -> Graphviz SVG view
+//   - @terrastruct/d2         -> D2 diagram view (browser build, wasm embedded)
 //
-// The chunk carries a content hash in its filename, so we locate it
-// structurally rather than by name: the largest dist/assets/*.js that is
-// NOT referenced by dist/index.html (i.e. not an entry/preloaded chunk) and
-// that contains the string "Graphviz".
+// These budgets are REGRESSION DETECTORS, not hard limits. Per owner policy the
+// large D2 chunk (multi-MB) is acceptable; the point of this check is to catch
+// SUDDEN growth -- e.g. a dependency bump that inlines more, or an accidental
+// static import that folds an engine into the entry bundle and defeats the lazy
+// load. Each budget is the last measured size plus ~30% headroom. When a change
+// intentionally moves a size, update the corresponding BUDGET here in the same
+// PR and note why; do not treat the number as a ceiling to defend.
 //
-// Measured 2026-07-08 (vite build): raw ~794 KiB, gzip ~618 KiB. The chunk
-// embeds the Graphviz wasm as base64, hence the poor gzip ratio. Budgets are
-// measured + ~30% headroom; lower them after intentional size wins, raise
-// them only with justification in the same PR.
+// Chunks carry a content hash in their filename, so we locate them structurally
+// rather than by name: the largest dist/assets/*.js that is NOT referenced by
+// dist/index.html (i.e. not an entry/preloaded chunk) and that contains a
+// distinctive marker string for the engine.
+//
+// Measured 2026-07-08 (vite build):
+//   Graphviz: raw ~794 KiB, gzip ~618 KiB (wasm embedded as base64).
+//   D2:       raw ~7997 KiB, gzip ~5849 KiB (browser build embeds its wasm and
+//             wasm_exec.js, and inlines its web worker as a Blob URL).
 import { readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { gzipSync } from 'node:zlib';
@@ -22,10 +30,32 @@ import { gzipSync } from 'node:zlib';
 const ASSETS_DIR = 'dist/assets';
 const INDEX_HTML = 'dist/index.html';
 
-const BUDGETS = {
-  raw: 1.05 * 1024 * 1024, // ~1.05 MiB
-  gzip: 820 * 1024, // ~820 KiB
-};
+// One entry per lazily-loaded engine chunk. `marker` is a distinctive string
+// that survives minification and appears only in that engine's chunk; budgets
+// are measured + ~30%.
+const CHUNKS = [
+  {
+    label: 'Graphviz',
+    // @hpcc-js/wasm-graphviz exposes a "Graphviz" class; the entry chunk also
+    // mentions it but is excluded below as an index.html reference.
+    marker: 'Graphviz',
+    budgets: {
+      raw: 1.05 * 1024 * 1024, // ~1.05 MiB
+      gzip: 820 * 1024, // ~820 KiB
+    },
+  },
+  {
+    label: 'D2',
+    // @terrastruct/d2's browser build references its embedded wasm as
+    // "d2.wasm" (a string literal in the inlined worker loader); this appears
+    // only in the D2 chunk.
+    marker: 'd2.wasm',
+    budgets: {
+      raw: 10.4 * 1024 * 1024, // ~10.4 MiB
+      gzip: 7.6 * 1024 * 1024, // ~7.6 MiB
+    },
+  },
+];
 
 const kib = (n) => `${(n / 1024).toFixed(1)} KiB`;
 
@@ -49,43 +79,48 @@ try {
 }
 
 // Consider only lazily-loaded chunks: drop anything index.html references
-// directly (the entry chunk and any modulepreload targets).
-const candidates = assetFiles
+// directly (the entry chunk and any modulepreload targets). Read each once.
+const lazyChunks = assetFiles
   .filter((f) => !indexHtml.includes(f))
-  .map((f) => ({ name: f, content: readFileSync(join(ASSETS_DIR, f)) }))
-  // Buffer.includes(string) checks the utf8 bytes; the entry chunk also
-  // mentions "Graphviz" but is already excluded above as an index.html ref.
-  .filter(({ content }) => content.includes('Graphviz'))
-  .sort((a, b) => b.content.length - a.content.length);
-
-if (candidates.length === 0) {
-  fail(
-    'Could not locate the Graphviz chunk: no non-entry dist/assets/*.js ' +
-    'contains "Graphviz". Did the build change how @hpcc-js/wasm-graphviz is ' +
-    'bundled (e.g. it is now statically imported into the entry chunk)? ' +
-    'Update scripts/check-chunk-size.mjs.'
-  );
-}
-
-const chunk = candidates[0];
-const sizes = {
-  raw: chunk.content.length,
-  gzip: gzipSync(chunk.content, { level: 9 }).length,
-};
-
-console.log(`info Graphviz chunk: ${chunk.name}`);
+  .map((f) => ({ name: f, content: readFileSync(join(ASSETS_DIR, f)) }));
 
 let failed = false;
-for (const [kind, size] of Object.entries(sizes)) {
-  const budget = BUDGETS[kind];
-  const ok = size <= budget;
-  console.log(`${ok ? 'OK  ' : 'FAIL'} ${kind.padEnd(5)} ${kib(size)} (budget ${kib(budget)})`);
-  if (!ok) failed = true;
+
+for (const { label, marker, budgets } of CHUNKS) {
+  // Buffer.includes(string) checks the utf8 bytes.
+  const candidates = lazyChunks
+    .filter(({ content }) => content.includes(marker))
+    .sort((a, b) => b.content.length - a.content.length);
+
+  if (candidates.length === 0) {
+    fail(
+      `Could not locate the ${label} chunk: no non-entry dist/assets/*.js ` +
+      `contains "${marker}". Did the build change how the engine is bundled ` +
+      `(e.g. it is now statically imported into the entry chunk)? Update ` +
+      `scripts/check-chunk-size.mjs.`
+    );
+  }
+
+  const chunk = candidates[0];
+  const sizes = {
+    raw: chunk.content.length,
+    gzip: gzipSync(chunk.content, { level: 9 }).length,
+  };
+
+  console.log(`info ${label} chunk: ${chunk.name}`);
+  for (const [kind, size] of Object.entries(sizes)) {
+    const budget = budgets[kind];
+    const ok = size <= budget;
+    console.log(`${ok ? 'OK  ' : 'FAIL'} ${label} ${kind.padEnd(5)} ${kib(size)} (budget ${kib(budget)})`);
+    if (!ok) failed = true;
+  }
 }
 
 if (failed) {
   fail(
-    '\nGraphviz chunk budget exceeded. If the growth is intentional, adjust ' +
-    'BUDGETS in scripts/check-chunk-size.mjs in the same PR and explain why.'
+    '\nA lazy-chunk budget was exceeded. These budgets are regression ' +
+    'detectors, not hard limits: if the growth is intentional, raise the ' +
+    'matching BUDGET in scripts/check-chunk-size.mjs in the same PR and ' +
+    'explain why.'
   );
 }

--- a/src/components/InputPanel.tsx
+++ b/src/components/InputPanel.tsx
@@ -100,9 +100,9 @@ const InputPanel: React.FC<InputPanelProps> = ({ disabled }) => {
   // The diagram/svg/d2 views all build the plan via the spannerplanviz pipeline
   // and share the "full details" toggle instead of the ASCII text controls.
   const isPlanVizView = outputView === 'diagram' || outputView === 'svg' || outputView === 'd2';
-  // Only the rendered graphical views (diagram/svg) are zoomable; the D2 view is
-  // monospace source text, so it keeps the font-size controls like ASCII.
-  const isZoomableView = outputView === 'diagram' || outputView === 'svg';
+  // The rendered graphical views (diagram/svg/d2) all display an in-browser SVG,
+  // so they share the zoom controls; only the ASCII text view uses font-size.
+  const isZoomableView = outputView === 'diagram' || outputView === 'svg' || outputView === 'd2';
   const [showPlanInput, setShowPlanInput] = useState(false);
 
   const onFileUpload = (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/components/OutputPanel.tsx
+++ b/src/components/OutputPanel.tsx
@@ -12,7 +12,7 @@ import { useDiagramZoomGestures } from '../hooks/useDiagramZoomGestures';
 import { useScrollTracking } from '../hooks/useScrollTracking';
 
 const OutputPanel: React.FC = () => {
-  const { asciiOutput, diagramOutput, svgOutput, d2Output, message, isRendering } = useAppContext();
+  const { asciiOutput, diagramOutput, svgOutput, d2Output, d2SvgOutput, message, isRendering } = useAppContext();
   const { fontSize, diagramZoom, setDiagramZoom, outputView, registerDiagramFitHandler } = useSettingsContext();
   // WASM initializes lazily inside the render call, so the render lifecycle
   // (isRendering) is the single source of the loading indicator -- it covers
@@ -21,7 +21,7 @@ const OutputPanel: React.FC = () => {
   const isDiagramView = outputView === 'diagram';
   const isSvgView = outputView === 'svg';
   const isD2View = outputView === 'd2';
-  const isZoomableView = isDiagramView || isSvgView;
+  const isZoomableView = isDiagramView || isSvgView || isD2View;
   const activeOutput = isDiagramView
     ? diagramOutput
     : isSvgView
@@ -84,7 +84,7 @@ const OutputPanel: React.FC = () => {
     });
 
     return () => registerDiagramFitHandler(null);
-  }, [diagramOutput, svgOutput, registerDiagramFitHandler, setDiagramZoom]);
+  }, [diagramOutput, svgOutput, d2SvgOutput, registerDiagramFitHandler, setDiagramZoom]);
 
   return (
     <div className="content-container">
@@ -186,38 +186,19 @@ const OutputPanel: React.FC = () => {
 
       {isD2View && d2Output && (
         <div
-          className="pre-container"
+          className="output-panel-shell diagram-shell"
           data-testid="output-container"
         >
-          <div className="d2-hint" data-testid="d2-hint">
-            Render with the D2 CLI: <code>d2 plan.d2 plan.svg</code>
-          </div>
-          <pre
-            style={{
-              fontFamily: 'monospace',
-              whiteSpace: 'pre',
-              border: 'solid',
-              padding: '10px',
-              marginTop: '0',
-              position: 'relative',
-              overflow: 'auto',
-              maxWidth: '100%',
-              flex: '1 1 auto',
-              boxSizing: 'border-box',
-              margin: '0',
-            }}
+          <div
+            className="diagram-scroll"
+            ref={diagramScrollRef}
+            data-testid="diagram-scroll"
+            title="Pinch or Ctrl+scroll (Cmd+scroll on Mac) to zoom the diagram"
           >
-            <code
-              style={{
-                fontFamily: "Consolas, 'Courier New', Courier, monospace",
-                fontSize: `${fontSize}px`,
-              }}
-              data-testid="d2-output-code"
-            >
-              {d2Output}
-            </code>
-          </pre>
-
+            {/* The D2 view renders the diagram in-browser via @terrastruct/d2;
+                Copy/Download still operate on the raw D2 source (d2Output). */}
+            <SvgPanel svg={d2SvgOutput} zoom={diagramZoom} />
+          </div>
           <OutputActionButtons
             content={d2Output}
             download={OUTPUT_DOWNLOAD.d2}

--- a/src/contexts/AppContext.tsx
+++ b/src/contexts/AppContext.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from 'react';
 import { createContextWithHook } from '../utils/createContextWithHook';
 import { useFileContext } from './FileContext';
 import { useSettingsContext } from './SettingsContext';
-import { renderASCIITree, renderMermaidDiagram, renderSVGDiagram, renderD2Source, isWasmInitialized } from '../wasm';
+import { renderASCIITree, renderMermaidDiagram, renderSVGDiagram, renderD2Diagram, isWasmInitialized } from '../wasm';
 import type { FormatType, PrintSection, RenderAppendixOptions } from '../types/wasm';
 import { logger } from '../utils/logger';
 
@@ -21,7 +21,10 @@ interface AppState {
   asciiOutput: string;
   diagramOutput: string;
   svgOutput: string;
+  /** Raw D2 source (backs copy/download of the D2 view). */
   d2Output: string;
+  /** D2 diagram laid out to SVG in the browser (the D2 view's display). */
+  d2SvgOutput: string;
   message: string;
   isRendering: boolean;
 }
@@ -60,6 +63,7 @@ export const AppProvider: React.FC<AppProviderProps> = ({ children }) => {
   const [diagramOutput, setDiagramOutput] = useState<string>('');
   const [svgOutput, setSvgOutput] = useState<string>('');
   const [d2Output, setD2Output] = useState<string>('');
+  const [d2SvgOutput, setD2SvgOutput] = useState<string>('');
   const [isRendering, setIsRendering] = useState<boolean>(false);
   // The WASM module is initialized lazily on the first render (see wasm.ts),
   // so the app is immediately usable and starts in a ready state.
@@ -86,12 +90,17 @@ export const AppProvider: React.FC<AppProviderProps> = ({ children }) => {
 
     try {
       let rendered: string;
+      // The D2 view renders an in-browser SVG (d2Svg) while keeping the raw
+      // source (rendered) for copy/download.
+      let d2Svg = '';
       if (outputView === 'diagram') {
         rendered = await renderMermaidDiagram(input, { full: diagramFull });
       } else if (outputView === 'svg') {
         rendered = await renderSVGDiagram(input, { full: diagramFull });
       } else if (outputView === 'd2') {
-        rendered = await renderD2Source(input, { full: diagramFull });
+        const d2Result = await renderD2Diagram(input, { full: diagramFull });
+        rendered = d2Result.source;
+        d2Svg = d2Result.svg;
       } else {
         const appendixOptions: RenderAppendixOptions = {
           showScalarVars,
@@ -108,6 +117,7 @@ export const AppProvider: React.FC<AppProviderProps> = ({ children }) => {
         setSvgOutput(rendered);
       } else if (outputView === 'd2') {
         setD2Output(rendered);
+        setD2SvgOutput(d2Svg);
       } else {
         setAsciiOutput(rendered);
       }
@@ -128,6 +138,7 @@ export const AppProvider: React.FC<AppProviderProps> = ({ children }) => {
         setSvgOutput('');
       } else if (outputView === 'd2') {
         setD2Output('');
+        setD2SvgOutput('');
       } else {
         setAsciiOutput('');
       }
@@ -207,6 +218,7 @@ export const AppProvider: React.FC<AppProviderProps> = ({ children }) => {
     diagramOutput,
     svgOutput,
     d2Output,
+    d2SvgOutput,
     message,
     isRendering,
     handleRender,

--- a/src/index.css
+++ b/src/index.css
@@ -316,21 +316,6 @@ textarea.input-area {
   min-height: 0;
 }
 
-.d2-hint {
-  padding: 6px 10px;
-  font-size: 13px;
-  color: #495057;
-  background-color: #f0f8ff;
-  border-bottom: 1px solid #dee2e6;
-}
-
-.d2-hint code {
-  font-family: Consolas, 'Courier New', Courier, monospace;
-  background-color: #e9ecef;
-  padding: 1px 4px;
-  border-radius: 3px;
-}
-
 /* Rendering control styles */
 .render-controls {
   /* display: flex; Removed as it's now a column flex container */

--- a/src/types/wasm.ts
+++ b/src/types/wasm.ts
@@ -43,7 +43,7 @@ export interface RenderAppendixOptions {
  * - ascii: Text tree rendered by spannerplan/plantree
  * - diagram: Mermaid.js diagram rendered in the browser
  * - svg: Graphviz SVG laid out in the browser from spannerplanviz DOT source
- * - d2: D2 (https://d2lang.com) diagram source text; render externally with the d2 CLI
+ * - d2: D2 (https://d2lang.com) diagram laid out in the browser via @terrastruct/d2; the raw D2 source stays copy/downloadable
  */
 export type OutputView = "ascii" | "diagram" | "svg" | "d2";
 
@@ -149,8 +149,9 @@ export interface WasmFunctions {
   renderDOT: (paramsJson: string) => string;
   /**
    * Renders Spanner query plan as D2 (https://d2lang.com) diagram source text.
-   * The result is unlaid-out D2 source; render it externally with the d2 CLI
-   * (for example `d2 plan.d2 plan.svg`). No in-browser rendering is performed.
+   * The result is unlaid-out D2 source. Layout to SVG is done by the JS layer
+   * (`renderD2Diagram` in src/wasm.ts, via @terrastruct/d2); the same source is
+   * also copy/downloadable for external use with the d2 CLI.
    * @param paramsJson - JSON string containing RenderPlanVizParams
    * @returns JSON string containing WasmResponse
    */

--- a/src/wasm.ts
+++ b/src/wasm.ts
@@ -189,9 +189,9 @@ export async function renderMermaidDiagram(
 /**
  * Render D2 (https://d2lang.com) diagram source text for a query plan via WASM.
  *
- * Unlike the SVG view, no in-browser layout happens: the official D2 browser
- * bundle is far too large to ship, so this returns the raw D2 source for the
- * user to render externally with the d2 CLI (for example `d2 plan.d2 plan.svg`).
+ * Returns the raw D2 source only (no layout). This backs the copy/download
+ * actions and is the input to {@link renderD2Diagram}, which additionally lays
+ * it out to SVG in the browser.
  */
 export async function renderD2Source(
   input: string,
@@ -261,6 +261,72 @@ export async function renderSVGDiagram(
   } catch (e) {
     const { message, originalError } = extractErrorInfo(e);
     logger.error('Error during SVG rendering:', message);
+    throw new WasmRenderingError(message, originalError);
+  }
+}
+
+// The D2 renderer (@terrastruct/d2) is imported dynamically so its large
+// (~8 MB) wasm-bearing browser bundle is only downloaded when the D2 view is
+// actually used. The browser build is fully self-contained: it spawns its own
+// web worker from an inlined Blob URL and embeds both the D2 wasm and its
+// wasm_exec.js, so no extra asset files or network fetches are involved. The
+// D2 instance is cached and reused across renders.
+let d2Promise: Promise<import('@terrastruct/d2').D2> | null = null;
+
+async function loadD2(): Promise<import('@terrastruct/d2').D2> {
+  if (!d2Promise) {
+    d2Promise = import('@terrastruct/d2')
+      .then(({ D2 }) => new D2())
+      .catch((err: unknown) => {
+        // Allow a retry on the next call instead of caching the failure.
+        d2Promise = null;
+        throw err;
+      });
+  }
+  return d2Promise;
+}
+
+/**
+ * Result of rendering a query plan as a D2 diagram.
+ */
+export interface D2RenderResult {
+  /** Raw D2 source text; backs the copy/download (.d2) actions. */
+  source: string;
+  /** The diagram laid out to SVG in the browser via @terrastruct/d2. */
+  svg: string;
+}
+
+/**
+ * Render a query plan as a D2 (https://d2lang.com) diagram.
+ *
+ * The Go WASM module emits D2 source (see {@link renderD2Source}); layout and
+ * SVG generation happen in the browser via the lazily-loaded @terrastruct/d2
+ * package, so the Go binary does not embed a D2 runtime. The raw source is
+ * returned alongside the SVG so the copy/download actions keep operating on the
+ * D2 source.
+ */
+export async function renderD2Diagram(
+  input: string,
+  options: Omit<RenderPlanVizParams, 'input'> = { full: true }
+): Promise<D2RenderResult> {
+  logger.info('renderD2Diagram called');
+
+  // Reuse the source path (it initializes WASM and returns D2 source), then
+  // lay it out to SVG in the browser.
+  const source = await renderD2Source(input, options);
+
+  try {
+    const d2 = await loadD2();
+    const layoutStart = performance.now();
+    const { diagram, renderOptions } = await d2.compile(source);
+    // noXMLTag omits the leading <?xml ...?> so the SVG embeds cleanly via
+    // innerHTML in SvgPanel (per the @terrastruct/d2 README recommendation).
+    const svg = await d2.render(diagram, { ...renderOptions, noXMLTag: true });
+    logger.info(`D2 layout completed in ${(performance.now() - layoutStart).toFixed(2)}ms`);
+    return { source, svg };
+  } catch (e) {
+    const { message, originalError } = extractErrorInfo(e);
+    logger.error('Error during D2 layout:', message);
     throw new WasmRenderingError(message, originalError);
   }
 }

--- a/tests/d2-rendering.spec.ts
+++ b/tests/d2-rendering.spec.ts
@@ -3,25 +3,29 @@ import {
   setupCompleteTest,
   uploadTestFile,
   selectOutputView,
+  waitForDiagramComplete,
 } from './utils';
 
 const DEBUG = process.env.DEBUG === 'true';
 
-test.describe('D2 Source Rendering', () => {
+test.describe('D2 Diagram Rendering', () => {
   test.setTimeout(120000);
 
-  test('should render a query plan as D2 source text', async ({ page }) => {
+  test('should render a query plan as a D2 diagram', async ({ page }) => {
     await setupCompleteTest(page, test, { debug: DEBUG });
     await selectOutputView(page, 'd2');
     await uploadTestFile(page, 'dca_profile.yaml');
 
-    const output = page.getByTestId('d2-output-code');
-    await expect(output).toContainText('direction: down', { timeout: 60000 });
-    await expect(output).toContainText('node0');
-    await expect(output).toContainText(/Distributed/i);
-
-    // The hint tells users how to render the source externally with the d2 CLI.
-    await expect(page.getByTestId('d2-hint')).toContainText('d2 plan.d2 plan.svg');
+    // The D2 view now lays the diagram out in-browser via @terrastruct/d2 and
+    // shows the resulting SVG (the first render also downloads the large lazy
+    // D2 chunk, hence the generous timeout).
+    await waitForDiagramComplete(page);
+    const diagram = page.getByTestId('diagram-output');
+    await expect(diagram).toBeVisible();
+    // D2 embeds per-shape icon <svg> elements, so scope to the outer diagram SVG.
+    const outerSvg = diagram.locator('svg').first();
+    await expect(outerSvg).toBeVisible();
+    await expect(outerSvg).toContainText(/Distributed/i);
   });
 
   test('should switch between ASCII and D2 views', async ({ page }) => {
@@ -31,20 +35,22 @@ test.describe('D2 Source Rendering', () => {
     await expect(page.getByTestId('output-code')).toContainText('Distributed Union', { timeout: 60000 });
 
     await selectOutputView(page, 'd2');
-    await expect(page.getByTestId('d2-output-code')).toContainText('direction: down', { timeout: 60000 });
+    await waitForDiagramComplete(page);
+    await expect(page.getByTestId('diagram-output').locator('svg').first()).toBeVisible();
     await expect(page.getByTestId('output-code')).toHaveCount(0);
 
     await selectOutputView(page, 'ascii');
     await expect(page.getByTestId('output-code')).toContainText('Distributed Union', { timeout: 60000 });
-    await expect(page.getByTestId('d2-output-code')).toHaveCount(0);
+    await expect(page.getByTestId('diagram-output')).toHaveCount(0);
   });
 
-  test('should download D2 source with d2 extension', async ({ page }) => {
+  test('should download the D2 source with a d2 extension', async ({ page }) => {
     await setupCompleteTest(page, test, { debug: DEBUG });
     await selectOutputView(page, 'd2');
     await uploadTestFile(page, 'dca_profile.yaml');
-    await expect(page.getByTestId('d2-output-code')).toContainText('direction: down', { timeout: 60000 });
+    await waitForDiagramComplete(page);
 
+    // Copy/Download keep operating on the raw D2 source, not the rendered SVG.
     const downloadPromise = page.waitForEvent('download');
     await page.getByTestId('download-button').click();
     const download = await downloadPromise;
@@ -52,17 +58,18 @@ test.describe('D2 Source Rendering', () => {
     expect(download.suggestedFilename()).toBe('query-plan.d2');
   });
 
-  test('should keep D2 source copyable', async ({ page, browserName }) => {
+  test('should keep the D2 source copyable', async ({ page, browserName }) => {
     test.skip(browserName !== 'chromium', 'Clipboard permissions are configured for Chromium only');
 
     await setupCompleteTest(page, test, { debug: DEBUG });
     await selectOutputView(page, 'd2');
     await uploadTestFile(page, 'dca_profile.yaml');
-    await expect(page.getByTestId('d2-output-code')).toContainText('direction: down', { timeout: 60000 });
+    await waitForDiagramComplete(page);
 
     await page.getByTestId('copy-button').click();
     await expect(page.getByTestId('copy-button')).toHaveText(/copied/i, { timeout: 5000 });
 
+    // The clipboard carries the D2 source (not the SVG markup).
     const clipboardText = await page.evaluate(async () => navigator.clipboard.readText());
     expect(clipboardText).toContain('direction: down');
     expect(clipboardText).toContain('node0');

--- a/tests/render-error-and-view-switch.spec.ts
+++ b/tests/render-error-and-view-switch.spec.ts
@@ -58,9 +58,12 @@ test.describe('Render error visibility and single render on view switch', () => 
     await settle(page);
     const baselineRenderCount = countRenders(consoleMessages);
 
-    // Switch to the D2 source view.
+    // Switch to the D2 diagram view. The render counter is incremented
+    // synchronously at handleRender start (before any await), so it is already
+    // accurate regardless of how long the D2 layout / lazy-chunk load takes;
+    // still, wait for the diagram so the switch's render has actually run.
     await page.getByTestId('output-view-select').selectOption('d2');
-    await expect(page.getByTestId('d2-output-code')).toBeVisible({ timeout: 60000 });
+    await expect(page.getByTestId('diagram-output').locator('svg').first()).toBeVisible({ timeout: 60000 });
 
     // Wait past the auto-render debounce window (200ms) for any second render to
     // appear, then assert exactly one render happened for the view switch.


### PR DESCRIPTION
## Summary

Upgrades the **D2 view** from source-text-only to an in-browser rendered diagram. The Go WASM module still emits D2 source (`renderD2`, contract unchanged); the JS layer now lazily loads [`@terrastruct/d2`](https://www.npmjs.com/package/@terrastruct/d2) to compile + lay it out to SVG, shown in the same zoomable stage as the Graphviz SVG view. **Copy/Download keep operating on the raw D2 source (`.d2`)** so users can still render it externally with the d2 CLI.

## API actually used

Verified against `node_modules/@terrastruct/d2/index.d.ts` + README (v0.1.33):

```js
const d2 = new D2();                                  // cached, reused across renders
const { diagram, renderOptions } = await d2.compile(source);
const svg = await d2.render(diagram, { ...renderOptions, noXMLTag: true });
```

`noXMLTag: true` strips the leading `<?xml ?>` so the SVG embeds cleanly via `innerHTML` in `SvgPanel` (README recommendation).

## Vite bundling outcome (worker / wasm)

The riskiest part — verified working in a **production build + preview**, not just dev.

- The browser build (`dist/browser/index.js`) is **fully self-contained**: it spawns its own web worker from an **inlined Blob URL** (`new Worker(URL.createObjectURL(blob), { type: 'module' })`) and **embeds both the D2 wasm and its `wasm_exec.js` as data** (no external fetches, no `import.meta.url`-relative asset resolution). So Vite has nothing to mangle — no `optimizeDeps.exclude` or explicit-entry workarounds were needed.
- Because it is a dynamic `import()` (mirroring `loadGraphviz`), Rollup splits it into its own lazy chunk that is **not** referenced by `index.html` (confirmed lazy). First D2 render downloads it; subsequent renders reuse the cached `D2` instance.
- Rendered output confirmed in preview: outer `<svg viewBox="0 0 1462 6503" data-d2-version="v0.7.0-HEAD">` with the expected operator labels. (D2 embeds per-shape icon `<svg>` elements, so tests scope to the outer SVG via `.first()`.)

## Measured chunk sizes & budgets (regression detectors, not hard limits)

`scripts/check-chunk-size.mjs` now tracks both lazy chunks; header restated per owner policy that budgets detect *sudden growth*, not enforce ceilings. Budget = measured + ~30%.

| Chunk | Raw | Gzip | Raw budget | Gzip budget |
|-------|-----|------|-----------|-------------|
| D2 | 7997.2 KiB | 5849.0 KiB | ~10.4 MiB | ~7.6 MiB |
| Graphviz | 794.5 KiB | 618.3 KiB | ~1.05 MiB | ~820 KiB |

The multi-MB D2 chunk is accepted (owner policy recalibration): bundle-size budgets are regression detectors, so shipping the official ~8 MB D2 browser build (wasm embedded) lazily is fine.

## UI decisions

- **SvgPanel reuse:** reused directly (no new component). `OutputPanel`'s D2 branch renders the same `diagram-shell` / `diagram-scroll` / `SvgPanel` structure as the SVG view, so it inherits zoom, fit, and the `diagram-output` test id for free.
- **Zoom classification:** D2 moves from the font-size group to the zoom group in `InputPanel` (`isZoomableView`), and `OutputPanel` includes it in the zoomable set.
- **CLI hint dropped:** with the diagram now rendered inline, a "render externally with the d2 CLI" hint next to it read as confusing/redundant. The Download button (`.d2`) + Copy still expose the source for external use, so the affordance is preserved without the banner. Removed the now-unused `.d2-hint` CSS.
- **Loading:** the existing render lifecycle (`Loading rendering engine...` / `Rendering...`) covers the first-chunk download; no separate D2-specific message was added.

## Gates (all green)

- `npm run lint` ✓
- `npm run typecheck` ✓
- `npx vitest run` — 86 passed (WASM `renderD2` contract unchanged)
- `npx playwright test --project=chromium` (dev) — 26 passed
- `npm run build && npx playwright test --project=chromium --config=playwright.preview.config.ts` (**preview, mandatory**) — 26 passed
- `npm run check:wasm-size` ✓
- `npm run check:chunk-size` ✓ (both chunks)
- `go test ./...` ✓ (Go untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Du9UR1LPdSXk4wAZr4Nf4g