### PR TITLE
chore(deps): bump spannerplanviz to v0.10.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/apstndb/spannerplan v0.2.1
-	github.com/apstndb/spannerplanviz v0.10.1
+	github.com/apstndb/spannerplanviz v0.10.2
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/apstndb/protoyaml v0.1.0 h1:xbps9Yly1rciJhLOFdA+KLIdEpEcIaTCboFB3QtUM
 github.com/apstndb/protoyaml v0.1.0/go.mod h1:bsZCSj3nYZKfLiKRogOxuUjlURUOJpBb+G5f1b3g5Fc=
 github.com/apstndb/spannerplan v0.2.1 h1:vzuUI2u1x+tF/ZGRYutnVJbF/n51RxIgOhn+MoNBaiE=
 github.com/apstndb/spannerplan v0.2.1/go.mod h1:X61lDATo/rDsn9gHTvlOUfm0SItUFL32QJWcRHalWnA=
-github.com/apstndb/spannerplanviz v0.10.1 h1:iF8QP9e/CkgOpTYXuJTDVdViSqvTumRvcHRYEpb6H5Y=
-github.com/apstndb/spannerplanviz v0.10.1/go.mod h1:1g6dWQcxamHr/2VgVoQSW1vGogZ/J7+ZESYRNEFjAxU=
+github.com/apstndb/spannerplanviz v0.10.2 h1:OnhNs9/p4kUy8ghblzeyleDd60+Ww9Mz6I8AceMUUEw=
+github.com/apstndb/spannerplanviz v0.10.2/go.mod h1:1g6dWQcxamHr/2VgVoQSW1vGogZ/J7+ZESYRNEFjAxU=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/clipperhouse/displaywidth v0.11.0 h1:lBc6kY44VFw+TDx4I8opi/EtL9m20WSEFgwIwO+UVM8=


### PR DESCRIPTION
Picks up the D2 label typography fix (apstndb/spannerplanviz#61): tight hard-break line spacing and valid CommonMark italics with preserved indentation. Look and feel accepted after local verification against the fixed branch. Unit 86/86, WASM budgets green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Du9UR1LPdSXk4wAZr4Nf4g