### PR TITLE
chore: pin @types/node to Node 22 runtime major

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,10 @@ updates:
     groups:
       npm-minor-patch:
         update-types: ["minor", "patch"]
+    ignore:
+      # @types/node tracks the Node runtime major (engines/CI); bump them together.
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@playwright/test": "^1.61.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
-        "@types/node": "^20.10.0",
+        "@types/node": "^22.20.1",
         "@types/react": "^18.2.37",
         "@types/react-dom": "^18.2.15",
         "@typescript-eslint/eslint-plugin": "^8.62.1",
@@ -2127,9 +2127,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.0.tgz",
-      "integrity": "sha512-hfrc+1tud1xcdVTABC2JiomZJEklMcXYNTVtZLAeqTVWD+qL5jkHKT+1lOtqDdGxt+mB53DTtiz673vfjU8D1Q==",
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@playwright/test": "^1.61.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
-    "@types/node": "^20.10.0",
+    "@types/node": "^22.20.1",
     "@types/react": "^18.2.37",
     "@types/react-dom": "^18.2.15",
     "@typescript-eslint/eslint-plugin": "^8.62.1",


### PR DESCRIPTION
## Summary

- The app runtime targets Node 22 (`engines.node >=22`, CI `node-version: 22`), so `@types/node` should track that major. Dependabot PR #32 proposed `@types/node` 26, which would let code typecheck against APIs the Node 22 runtime does not actually have.
- Bump `@types/node` from `^20.10.0` to `^22.20.1` (matches the runtime major) and regenerate `package-lock.json`.
- Add a `dependabot.yml` ignore rule for `@types/node` semver-major updates so future Dependabot PRs don't propose types ahead of the runtime; bump both together intentionally when the Node engine bumps.

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npx vitest run` (86 tests passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Du9UR1LPdSXk4wAZr4Nf4g