### PR TITLE
chore(deps): upgrade to React 19

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,8 @@
         "@terrastruct/d2": "^0.1.33",
         "loglevel": "^1.9.2",
         "mermaid": "^11.16.0",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react": "^19.2.7",
+        "react-dom": "^19.2.7"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -22,8 +22,8 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@types/node": "^22.20.1",
-        "@types/react": "^18.2.37",
-        "@types/react-dom": "^18.2.15",
+        "@types/react": "^19.2.17",
+        "@types/react-dom": "^19.2.3",
         "@typescript-eslint/eslint-plugin": "^8.63.0",
         "@typescript-eslint/parser": "^8.63.0",
         "@vitejs/plugin-react": "^6.0.3",
@@ -1527,32 +1527,24 @@
         "undici-types": "~6.21.0"
       }
     },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.15",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
-      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/react": {
-      "version": "18.3.31",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
-      "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/prop-types": "*",
         "csstype": "^3.2.2"
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "18.3.7",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
-      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@types/react": "^18.0.0"
+        "@types/react": "^19.2.0"
       }
     },
     "node_modules/@types/trusted-types": {
@@ -3442,6 +3434,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/jsdom": {
@@ -3899,18 +3892,6 @@
         "url": "https://tidelift.com/funding/github/npm/loglevel"
       }
     },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "license": "MIT",
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
-      }
-    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -4319,28 +4300,24 @@
       }
     },
     "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
+        "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^18.3.1"
+        "react": "^19.2.7"
       }
     },
     "node_modules/react-is": {
@@ -4450,13 +4427,10 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.8.5",

--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@types/node": "^22.20.1",
-    "@types/react": "^18.2.37",
-    "@types/react-dom": "^18.2.15",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
     "@typescript-eslint/eslint-plugin": "^8.63.0",
     "@typescript-eslint/parser": "^8.63.0",
     "@vitejs/plugin-react": "^6.0.3",
@@ -69,7 +69,7 @@
     "@terrastruct/d2": "^0.1.33",
     "loglevel": "^1.9.2",
     "mermaid": "^11.16.0",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7"
   }
 }

--- a/src/hooks/useScrollTracking.ts
+++ b/src/hooks/useScrollTracking.ts
@@ -14,8 +14,8 @@ import { measureCharacterWidth } from '../utils/characterMeasurement';
  * @returns Object containing scroll position and ruler width
  */
 export const useScrollTracking = (
-  preRef: React.RefObject<HTMLPreElement>,
-  codeRef: React.RefObject<HTMLElement>,
+  preRef: React.RefObject<HTMLPreElement | null>,
+  codeRef: React.RefObject<HTMLElement | null>,
   output: string,
   fontSize: number,
   fontFamily: string = "Consolas, 'Courier New', Courier, monospace"


### PR DESCRIPTION
## Summary

Upgrades React and its type definitions from 18 to 19, superseding Dependabot PR #31 which failed CI on the type-only breakage below.

## Version matrix

| Package | Before | After |
|---|---|---|
| `react` | `^18.2.0` | `^19.2.7` |
| `react-dom` | `^18.2.0` | `^19.2.7` |
| `@types/react` | `^18.2.37` | `^19.2.17` |
| `@types/react-dom` | `^18.2.15` | `^19.2.3` |

## React 19 upgrade guide items checked

Per https://react.dev/blog/2024/04/25/react-19-upgrade-guide, the following breaking changes were checked against this codebase:

- **Removed: `defaultProps` on function components** — not used anywhere in `src/`.
- **Removed: legacy string refs** — not used (the one `ref="..."` grep hit was an anchor `rel` attribute, unrelated).
- **Removed: legacy context (`contextTypes`/`getChildContext`)** — not used; the app uses `createContext`/`useContext` (`AppContext`, `SettingsContext`, `FileContext`).
- **`ref` as a prop / `forwardRef` deprecation** — no component uses `forwardRef`, so nothing to migrate.
- **`useRef()` requiring an argument** — all 6 `useRef` call sites already pass an initial value; none needed changes.
- **`createRoot` (already required in React 18/19)** — `src/main.tsx` already used `ReactDOM.createRoot`, no change needed.
- **`StrictMode` double-invoked effects on mount** — unchanged behavior between 18 and 19; verified via the existing render-count e2e test (see below).
- **TypeScript: `RefObject<T>` type now requires `T | null` where a ref can start `null`** — this was the one actual breakage; see code changes below.

## Code changes

- `src/hooks/useScrollTracking.ts`: widened `preRef`/`codeRef` parameter types from `React.RefObject<HTMLPreElement>` / `React.RefObject<HTMLElement>` to `React.RefObject<HTMLPreElement | null>` / `React.RefObject<HTMLElement | null>`. React 19's updated `@types/react` makes `RefObject<T>` exact (no implicit `| null`), and the callers pass refs created via `useRef<HTMLPreElement>(null)`, so the parameter types needed to allow `null` explicitly. Maps to the guide's TypeScript ref-typing changes.
- `package.json` / `package-lock.json`: dependency bumps only.

No other source changes were required.

## Test plan

All gates run locally on this branch:

- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npx vitest run` — 86/86 passed
- [x] `npx playwright test --project=chromium` (dev, full suite) — 26/26 passed, including `render-error-and-view-switch.spec.ts` (StrictMode/render-count regression test)
- [x] `npm run build` — succeeds
- [x] `npm run check:wasm-size` — within budget (raw 24.35 MiB / 28.00 MiB, gzip 5.27 MiB / 6.50 MiB, brotli 3.71 MiB / 5.50 MiB)
- [x] `npm run check:chunk-size` — within budget (Graphviz and D2 chunks both under budget)
- [x] `npx playwright test --project=chromium --config=playwright.preview.config.ts` (preview, full suite) — 26/26 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Du9UR1LPdSXk4wAZr4Nf4g